### PR TITLE
Fix confused translation and add more detailed description

### DIFF
--- a/cf/i18n/resources/zh/cf/actors/zh_CN.all.json
+++ b/cf/i18n/resources/zh/cf/actors/zh_CN.all.json
@@ -10,7 +10,7 @@
 
    {
       "id": "The route {{.URL}} is already in use.\nTIP: Change the hostname with -n HOSTNAME or use --random-route to generate a new route and then push again.",
-      "translation": "路由 {{.URL}} 已被使用\nTIP: 使用-n HOSTNAME 命令行改变主机名称，或使用--random-route命令生成一个新路由，然后使用push命令"
+      "translation": "路由 {{.URL}} 已被占用\nTIP: 请使用-n HOSTNAME 命令行改变主机名称，或使用--random-route命令生成一个新路由，然后重新使用push命令"
    },
    {
       "id": "Removing route {{.URL}}...",

--- a/cf/i18n/resources/zh/cf/app/zh_CN.all.json
+++ b/cf/i18n/resources/zh/cf/app/zh_CN.all.json
@@ -93,7 +93,7 @@
    },
    {
       "id": "Override path to default config directory",
-      "translation": "修改配置文件config.json的路径（默认为～/.cf）"
+      "translation": "修改cf配置文件config.json的路径（该路径默认为～/.cf）"
    },
    {
       "id": "Print the version",

--- a/cf/i18n/resources/zh/cf/app/zh_CN.all.json
+++ b/cf/i18n/resources/zh/cf/app/zh_CN.all.json
@@ -61,11 +61,11 @@
    },
    {
       "id": "Do not colorize output",
-      "translation": "禁止彩色输出, 彩打"
+      "translation": "禁止彩色输出"
    },
    {
       "id": "Print API request diagnostics to stdout",
-      "translation": "打印API请求诊断到标准输出"
+      "translation": "打印API请求诊断信息到标准输出"
    },
    {
       "id": "NAME:",
@@ -93,7 +93,7 @@
    },
    {
       "id": "Override path to default config directory",
-      "translation": "将默认配置路径替换成path/to/dir"
+      "translation": "修改配置文件config.json的路径（默认为～/.cf）"
    },
    {
       "id": "Print the version",
@@ -101,7 +101,7 @@
    },
    {
       "id": "BUILD TIME:",
-      "translation": "生成时间:"
+      "translation": "构建时间:"
    },
    {
       "id": "Max wait time for app instance startup, in minutes",
@@ -109,7 +109,7 @@
    },
    {
       "id": "Append API request diagnostics to a log file",
-      "translation": "追加API请求诊断到日志文件"
+      "translation": "追加API请求诊断信息到日志文件"
    },
    {
       "id": "Enable HTTP proxying for API requests",


### PR DESCRIPTION
"already in use" means " 占用"
“彩打” is a typo which is not needed
"Override path to default config directory" means that you can override the CF_HOME to your own dir, so we need to specify what's CF_HOME and what it for.
